### PR TITLE
feat(mgb72-scheduling-filter): create a filter for list scheduling

### DIFF
--- a/app/(dashboard)/barberlist/page.tsx
+++ b/app/(dashboard)/barberlist/page.tsx
@@ -75,7 +75,18 @@ export default function BarberList() {
     try {
       setIsLoading(true);
       const schedulings = await fetchPendingSchedulings(barberId);
-      setPendingSchedulings(schedulings);
+
+      const today = new Date();
+      today.setHours(0, 0, 0, 0);
+
+      const todaySchedulings = schedulings.filter(scheduling => {
+        const schedulingDate = new Date(scheduling.dayAt);
+        const schedulingDateLocal = new Date(schedulingDate.getFullYear(), schedulingDate.getMonth(), schedulingDate.getDate());
+        const todayLocal = new Date(today.getFullYear(), today.getMonth(), today.getDate());
+        return schedulingDateLocal.getTime() === todayLocal.getTime();
+      });
+
+      setPendingSchedulings(todaySchedulings);
     } catch (error) {
       Alert.alert("Erro", "Não foi possível carregar os agendamentos pendentes.");
     } finally {

--- a/app/(dashboard)/userlist/page.tsx
+++ b/app/(dashboard)/userlist/page.tsx
@@ -28,7 +28,6 @@ export default function UserList() {
   const [schedulingData, setSchedulingData] = useState<SchedulingData[]>([]);
   const [isLoading, setIsLoading] = useState(true);
 
-
   const fetchScheduling = useCallback(async () => {
     try {
       const response = await api.get<SchedulingData[]>('scheduling');
@@ -38,7 +37,19 @@ export default function UserList() {
         dayAt: typeof item.dayAt === 'string' ? new Date(item.dayAt) : item.dayAt,
       }));
 
-      const sortedData = dataWithDates.sort((a, b) => a.dayAt.getTime() - b.dayAt.getTime());
+      const today = new Date();
+      today.setHours(0, 0, 0, 0);
+      const tomorrow = new Date(today);
+      tomorrow.setDate(tomorrow.getDate() + 1);
+
+      const todaySchedulings = dataWithDates.filter(item => {
+        const itemDate = new Date(item.dayAt);
+        const itemDateLocal = new Date(itemDate.getFullYear(), itemDate.getMonth(), itemDate.getDate());
+        const todayLocal = new Date(today.getFullYear(), today.getMonth(), today.getDate());
+        return itemDateLocal.getTime() === todayLocal.getTime();
+      });
+
+      const sortedData = todaySchedulings.sort((a, b) => a.dayAt.getTime() - b.dayAt.getTime());
       setSchedulingData(sortedData);
     } catch (error: any) {
       Alert.alert("Erro ao carregar os agendamentos.");


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Filters barber pending schedulings and user scheduling lists to only show today’s appointments.
> 
> - **Dashboard**
>   - **`app/(dashboard)/barberlist/page.tsx`**: Filters fetched pending schedulings to only those occurring today before updating `pendingSchedulings`.
>   - **`app/(dashboard)/userlist/page.tsx`**: Processes `dayAt` as `Date`, filters schedulings to today only, then sorts by time before setting `schedulingData`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c0215ee482086e71e6aacc6d3f38b2e2ae71f22f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->